### PR TITLE
update java cookbook dependency

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -6,10 +6,10 @@ description      'Installs and execute flyway cli'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url       'https://github.com/ClouDesire/flyway-cli-cookbook' if respond_to?(:source_url)
 issues_url       'https://github.com/ClouDesire/flyway-cli-cookbook/issues' if respond_to?(:issues_url)
-version          '1.0.2'
+version          '1.0.3'
 supports         'ubuntu'
 supports         'windows'
 
-depends          'java', '<= 6.0.0'
+depends          'java', '<= 7.0.0'
 depends          'ark'
 depends          'compat_resource' # For custom resource compilation on chef-client versions < 12.5


### PR DESCRIPTION
The previous java cookbook has a regex which will not work with openjdk8 urls